### PR TITLE
Fix path handling in provider files

### DIFF
--- a/src/MeshEditorProvider.ts
+++ b/src/MeshEditorProvider.ts
@@ -125,9 +125,10 @@ export class MeshEditorProvider implements vscode.CustomReadonlyEditorProvider<M
         webviewPanel.webview.onDidReceiveMessage(e => {
             if (e.type === 'ready') {
                 const fileToLoad = document.uri.scheme === "file" ?
-                    document.uri.with({ scheme: 'vscode-resource' }) :
+                    webviewPanel.webview.asWebviewUri(vscode.Uri.file(document.uri.fsPath)) :
                     document.uri;
-                let body = {
+
+                const body = {
                     path: fileToLoad.toString(),
                     basename: path.basename(fileToLoad.fsPath),
                     dirname: path.dirname(fileToLoad.toString())

--- a/src/MeshViewerProvider.ts
+++ b/src/MeshViewerProvider.ts
@@ -177,12 +177,9 @@ export class MeshViewerProvider implements vscode.CustomReadonlyEditorProvider<M
      * Get the static HTML used for in our editor's webviews.
      */
     private getHtmlForWebview(webview: vscode.Webview, document: MeshViewerDocument): string {
-
-
-        let fileToLoad = document.uri.scheme === "file" ?
-            document.uri.with({ scheme: 'vscode-resource' }) :
+        const fileToLoad = document.uri.scheme === "file" ?
+            webview.asWebviewUri(vscode.Uri.file(document.uri.fsPath)) :
             document.uri;
-
 
         // Local path to script and css for the webview
         const scriptUri = webview.asWebviewUri(vscode.Uri.file(


### PR DESCRIPTION
Fix for an error created by the June 2020 update of VsCode that stopped models displaying in viewer & editor.
See #11.
Screenshots after applying changes (in v1.47.3):

![Jegyzet 2020-07-31 184012](https://user-images.githubusercontent.com/13366932/89057945-be38c700-d35e-11ea-83ca-ecbd01100e62.png)
![Jegyzet 2020-07-31 152522](https://user-images.githubusercontent.com/13366932/89058707-158b6700-d360-11ea-9231-0bd96d7dab9c.png)

Fixes #11 