### PR TITLE
Add .ply format to README.md & keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Preview 3D models in VSCode
 ## Main Features
 
 ### Model Viewer
-Support multiple formats:
+Supported formats:
 * `3ds` 3D Studio Max
 * `dae` Collada digital asset exchange
 * `fbx` Filmbox
 * `stl` STereo-Lithography
 * `obj` Wavefront OBJ
+* `ply` Polygon File Format
 
 ![sponza](images/sponza.png)  
   

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "Collada",
         "fbx",
         "obj",
-        "stl"
+        "stl",
+        "ply"
     ],
     "categories": [
         "Other"


### PR DESCRIPTION
- The '.ply' format support wasn't mentioned in the README.md file.
- Also added the 'ply' keyword to the package.json file.
- Reworded 'Support multiple formats' to 'Supported formats' in README.md