### PR TITLE
Add .mtl file loading to .obj files

### DIFF
--- a/media/viewer.js
+++ b/media/viewer.js
@@ -176,6 +176,20 @@ function onProgress(xhr) {
 }
 
 function loadModel() {
+    if(modelLoader instanceof THREE.OBJLoader) {            
+        new THREE.MTLLoader().load(userSettings.fileToLoad.replace('.obj', '.mtl'), materials => {
+            modelLoader.setMaterials(materials);
+
+            loadModelFile();
+        }, _ => {  // Assume no .mtl file
+            loadModelFile();
+        });
+    }else{
+        loadModelFile();
+    }
+}
+
+function loadModelFile() {
     modelLoader.load(userSettings.fileToLoad, file => {
         const object = file.scene ? file.scene : file.isGeometry || file.isBufferGeometry ? new THREE.Mesh(file) : file;
         object.mixer = new THREE.AnimationMixer(object);

--- a/src/MeshViewerProvider.ts
+++ b/src/MeshViewerProvider.ts
@@ -121,6 +121,7 @@ export class MeshViewerProvider implements vscode.CustomReadonlyEditorProvider<M
             this.getMediaPath(scheme, 'examples/js/loaders/FBXLoader.js'),
             this.getMediaPath(scheme, 'examples/js/loaders/TDSLoader.js'),
             this.getMediaPath(scheme, 'examples/js/loaders/OBJLoader.js'),
+            this.getMediaPath(scheme, 'examples/js/loaders/MTLLoader.js'),
             this.getMediaPath(scheme, 'examples/js/loaders/STLLoader.js'),
             this.getMediaPath(scheme, 'examples/js/loaders/PLYLoader.js'),
             this.getMediaPath(scheme, 'viewer.js')


### PR DESCRIPTION
- Start loading .mtl files for .obj files
- The .mtl file's name is assumed to be the same as the .obj's