### PR TITLE
fix `Blocked a frame with origin from accessing a cross-origin frame` error

### DIFF
--- a/media/editor.js
+++ b/media/editor.js
@@ -1,7 +1,4 @@
 // VSCode webview doesn't support modal window
-window.alert = top.alert;
-window.confirm = top.confirm;
-
 window.URL = window.URL || window.webkitURL;
 window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
 


### PR DESCRIPTION
Cannot open edit mode with this codes in vscode 1.85.1